### PR TITLE
format numbers

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@ from flask import Flask, render_template, request, make_response, redirect
 from flask_htmx import HTMX
 import time
 import re
-from os import environ
 import transaction_database
 import transaction_details_database
 import recent_blocks_database
@@ -151,3 +150,14 @@ def get_transaction_details(signature):
         return render_template('transaction_details.html', config=this_config, transaction=maprows[0])
     else:
         return "Transaction not found", 404
+
+
+# format 123456789 to "123,456,789"
+@webapp.template_filter('lamports')
+def lamports_filter(number: int):
+    if number is None:
+        return ""
+    else:
+        # https://realpython.com/python-formatted-output/#the-group-subcomponent
+        # return format(number, ",.2f")
+        return format(number, ",")

--- a/app.py
+++ b/app.py
@@ -84,7 +84,7 @@ def get_block(slot):
 
 
 def is_slot_number(raw_string):
-    return re.fullmatch("[0-9]+", raw_string) is not None
+    return re.fullmatch("[0-9,]+", raw_string) is not None
 
 
 def is_block_hash(raw_string):
@@ -113,6 +113,7 @@ def search():
             return render_template('_search_noresult.html', config=this_config)
 
         if is_slot_number(search_string):
+            search_string = search_string.replace(',', '')
             maprows = list(recent_blocks_database.find_block_by_slotnumber(int(search_string)))
             if len(maprows):
                 return render_template('_blockslist.html', config=this_config, blocks=maprows)
@@ -161,3 +162,29 @@ def lamports_filter(number: int):
         # https://realpython.com/python-formatted-output/#the-group-subcomponent
         # return format(number, ",.2f")
         return format(number, ",")
+
+
+@webapp.template_filter('slotnumber')
+def slotnumber_filter(number: int):
+    if number is None:
+        return ""
+    else:
+        return format(number, ",")
+
+
+@webapp.template_filter('count')
+def count_filter(number: int):
+    if number is None:
+        return ""
+    else:
+        return format(number, ",")
+
+
+# railway version: None -> None
+@webapp.template_filter('map_count')
+def mapcount_filter(number: int):
+    if number is None:
+        return None
+    else:
+        return format(number, ",")
+

--- a/templates/_blockslist.html
+++ b/templates/_blockslist.html
@@ -13,7 +13,7 @@
         <tr>
             <td>
                 <span class="text-primary">
-                    <a hx-boost="true" href="/block/{{ block.slot }}">{{ block.slot }}</a>
+                    <a hx-boost="true" href="/block/{{ block.slot }}">{{ block.slot | slotnumber }}</a>
                 </span>
             </td>
             <td>

--- a/templates/_blockslist.html
+++ b/templates/_blockslist.html
@@ -67,10 +67,10 @@
                 
                 <div class="font-monospace">
                     <span class="d-inline-block" style="min-width:6em">
-                        <span class="text-primary">min:{{ block.prioritization_fees.p_min }}</span>
+                        <span class="text-primary">min:{{ block.prioritization_fees.p_min | lamports }}</span>
                     </span>
                     <span class="d-inline-block" style="min-width:6em">
-                        <span class="text-primary">max:{{ block.prioritization_fees.p_max }}</span>
+                        <span class="text-primary">max:{{ block.prioritization_fees.p_max | lamports }}</span>
                     </span>
                 </div>
 

--- a/templates/_txlist.html
+++ b/templates/_txlist.html
@@ -30,7 +30,7 @@
         <td>
             <div class="d-flex align-items-center font-monospace" style="width:400px">
                 <div class="text-truncate">
-                    <a href="/transaction/{{tx.signature}}">{{tx.signature}}</a>
+                    <a href="/transaction/{{tx.signature}}">{{ tx.signature }}</a>
                 </div>
             </div>
         </td>
@@ -40,8 +40,8 @@
                     {% for error in tx.errors_array %}
                     <tr>
                         <td>
-                            <span class="font-monospace text-danger" title="Slot {{error.slot}}">
-                                {{error.count}}x&nbsp;&nbsp;{{error.error}}
+                            <span class="font-monospace text-danger" title="Slot {{ error.slot | slotnumber }}">
+                                {{ error.count | count }}x&nbsp;&nbsp;{{ error.error }}
                             </span>
                         </td>
                     </tr>

--- a/templates/_txlist.html
+++ b/templates/_txlist.html
@@ -49,8 +49,8 @@
                 </table>
             </div>
         </td>
-        <td class="text-end"><span class="font-monospace">{{ tx.cu_requested|default('', True) }}</span></td>
-        <td class="text-end">{{ tx.prioritization_fees|default('', True) }}</td>
+        <td class="text-end"><span class="font-monospace">{{ tx.cu_requested | lamports }}</span></td>
+        <td class="text-end">{{ tx.prioritization_fees | lamports }}</td>
     </tr>
     {% endfor %}
 

--- a/templates/block_details.html
+++ b/templates/block_details.html
@@ -18,7 +18,7 @@
         <div class="container mt-n2">
             <div class="header">
                 <div class="header-body"><h6 class="header-pretitle">Details</h6>
-                    <h2 class="header-title">Block {{block.slot}}</h2></div>
+                    <h2 class="header-title">Block {{ block.slot | slotnumber }}</h2></div>
             </div>
             <div class="card">
                 <div class="card-header"><h3 class="card-header-title mb-0 d-flex align-items-center">Overview</h3>
@@ -28,7 +28,7 @@
                         <tbody class="list">
                         <tr>
                             <td class="w-100">Slot</td>
-                            <td class="text-lg-end font-monospace"><span class="font-monospace"><a href="https://explorer.solana.com//block/{{block.slot}}?cluster={{config.cluster}}">{{block.slot}}</a></span></td>
+                            <td class="text-lg-end font-monospace"><span class="font-monospace"><a href="https://explorer.solana.com//block/{{block.slot}}?cluster={{config.cluster}}">{{ block.slot | slotnumber }}</a></span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Blockhash</td>
@@ -37,35 +37,35 @@
                         </tr>
                         <tr>
                             <td class="w-100">Processed Transactions</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.processed_transactions}}</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.processed_transactions | count }}</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Successful Transactions</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.successful_transactions}}</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.successful_transactions | count }}</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Banking Stage Errors</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.banking_stage_errors or 'n/a'}}</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.banking_stage_errors | map_count or 'n/a'}}</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Prioritization Fees Median</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.supp_infos.p_median}} lamports/CU</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.supp_infos.p_median | lamports }} lamports/CU</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Prioritization Fees Min</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.supp_infos.p_min}} lamports/CU</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.supp_infos.p_min | lamports }} lamports/CU</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Prioritization Fees Max</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.supp_infos.p_max}} lamports/CU</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.supp_infos.p_max | lamports }} lamports/CU</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Prioritization Fees p75</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.supp_infos.p_75}} lamports/CU</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.supp_infos.p_75 | lamports }} lamports/CU</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Prioritization Fees p90</td>
-                            <td class="text-lg-end font-monospace"><span>{{block.supp_infos.p_90}} lamports/CU</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ block.supp_infos.p_90 | lamports }} lamports/CU</span></td>
                         </tr>
                         </tbody>
                     </table>
@@ -108,11 +108,11 @@
                                                 class="font-monospace"><span class="">{{write_account.key}}</span></span>
                                         </div>
                                     </a></td>
-                                <td>{{write_account.cu_requested}}</td>
-                                <td>{{write_account.cu_consumed}}</td>
-                                <td>{{write_account.max_pf}}</td>
-                                <td>{{write_account.min_pf}}</td>
-                                <td>{{write_account.median_pf}}</td>
+                                <td>{{ write_account.cu_requested | lamports }}</td>
+                                <td>{{ write_account.cu_consumed | lamports }}</td>
+                                <td>{{ write_account.max_pf | lamports }}</td>
+                                <td>{{ write_account.min_pf | lamports }}</td>
+                                <td>{{ write_account.median_pf | lamports }}</td>
                             </tr>
                         {% endfor %}
                         </tbody>
@@ -145,11 +145,11 @@
                                                 class="font-monospace"><span class="">{{write_account.key}}</span></span>
                                         </div>
                                     </a></td>
-                                <td>{{write_account.cu_requested}}</td>
-                                <td>{{write_account.cu_consumed}}</td>
-                                <td>{{write_account.max_pf}}</td>
-                                <td>{{write_account.min_pf}}</td>
-                                <td>{{write_account.median_pf}}</td>
+                                <td>{{ write_account.cu_requested | lamports }}</td>
+                                <td>{{ write_account.cu_consumed | lamports }}</td>
+                                <td>{{ write_account.max_pf | lamports }}</td>
+                                <td>{{ write_account.min_pf | lamports }}</td>
+                                <td>{{ write_account.median_pf | lamports }}</td>
                             </tr>
                         {% endfor %}
                         </tbody>

--- a/templates/transaction_details.html
+++ b/templates/transaction_details.html
@@ -141,11 +141,11 @@
                                             </div>
                                         </a>
                                     </td>
-                                    <td>{{write_account.cu_requested}}</td>
-                                    <td>{{write_account.cu_consumed}}</td>
-                                    <td>{{write_account.median_pf}}</td>
-                                    <td>{{write_account.min_pf}}</td>
-                                    <td>{{write_account.max_pf}}</td>
+                                    <td>{{ write_account.cu_requested | lamports }}</td>
+                                    <td>{{ write_account.cu_consumed | lamports }}</td>
+                                    <td>{{ write_account.median_pf | lamports }}</td>
+                                    <td>{{ write_account.min_pf | lamports }}</td>
+                                    <td>{{ write_account.max_pf | lamports }}</td>
 
                                 </tr>
                                 {% endfor %}

--- a/templates/transaction_details.html
+++ b/templates/transaction_details.html
@@ -32,7 +32,7 @@
                             <td class="text-lg-end font-monospace">
                                 <span class="font-monospace">
                                     <a href="https://explorer.solana.com/tx/{{transaction.signature}}?cluster={{config.cluster}}">
-                                        {{transaction.signature}}
+                                        {{ transaction.signature }}
                                     </a>
                                 </span>
                             </td>
@@ -40,34 +40,34 @@
                         <tr>
                             <td class="w-100">Executed</td>
                             <td class="text-lg-end font-monospace">
-                                <span>{{transaction.is_executed}}</span></td>
+                                <span>{{ transaction.is_executed }}</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Confirmed</td>
                             <td class="text-lg-end font-monospace">
-                                <span>{{transaction.is_confirmed}}</span></td>
+                                <span>{{ transaction.is_confirmed }}</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Processed slot</td>
                             <td class="text-lg-end font-monospace">
-                                <span><a hx-boost="true" href="/block/{{transaction.processed_slot}}">{{transaction.processed_slot}}</a></span></td>
+                                <span><a hx-boost="true" href="/block/{{transaction.processed_slot}}">{{ transaction.processed_slot | slotnumber }}</a></span></td>
                         </tr>
                         <tr>
                             <td class="w-100">First notification slot</td>
                             <td class="text-lg-end font-monospace">
-                                <span><a hx-boost="true" href="/block/{{transaction.first_notification_slot}}">{{transaction.first_notification_slot}}</a></span></td>
+                                <span><a hx-boost="true" href="/block/{{transaction.first_notification_slot}}">{{ transaction.first_notification_slot | slotnumber }}</a></span></td>
                         </tr>
                         <tr>
                             <td class="w-100">CU Requested</td>
-                            <td class="text-lg-end font-monospace"><span>{{transaction.cu_requested}}</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ transaction.cu_requested | lamports }}</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">Prioritization Fees</td>
-                            <td class="text-lg-end font-monospace"><span>{{transaction.prioritization_fees}}</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ transaction.prioritization_fees | lamports }}</span></td>
                         </tr>
                         <tr>
                             <td class="w-100">UTC timestamp</td>
-                            <td class="text-lg-end font-monospace"><span>{{transaction.timestamp_formatted}}</span></td>
+                            <td class="text-lg-end font-monospace"><span>{{ transaction.timestamp_formatted }}</span></td>
                         </tr>
                         </tbody>
                     </table>
@@ -79,7 +79,7 @@
                         <ul class="nav nav-tabs nav-overflow header-tabs">
                             <!-- note: local anchors are not hx-boost'ed -->
                             {% for slot in transaction.relevant_slots %}
-                                <li class="nav-item"><a class="nav-link" href="#relevant-slot-{{slot}}">Slot: {{slot}}</a></li>
+                                <li class="nav-item"><a class="nav-link" href="#relevant-slot-{{slot}}">Slot: {{ slot | slotnumber }}</a></li>
                             {% endfor %}
                         </ul>
                     </div>
@@ -88,7 +88,7 @@
 
             {% for slot in transaction.relevant_slots %}
                 <div id="relevant-slot-{{slot}}" class="card">
-                    <div class="card-header align-items-center"><h3 class="card-header-title">Errors in Slot {{slot}}</h3></div>
+                    <div class="card-header align-items-center"><h3 class="card-header-title">Errors in Slot {{ slot | slotnumber }}</h3></div>
 
                     <div class="table-responsive mb-0">
                         <table class="table table-sm table-nowrap card-table">
@@ -103,10 +103,10 @@
                                 {% if error.slot == slot %}
                                 <tr>
                                     <td>
-                                        <span class="text-danger">{{error.error}}</span>
+                                        <span class="text-danger">{{ error.error }}</span>
                                     </td>
                                     <td>
-                                        <span class="text-danger">{{error.count}}</span>
+                                        <span class="text-danger">{{ error.count | count }}</span>
                                     </td>
                                 </tr>
                                 {% endif %}
@@ -137,7 +137,7 @@
                                         <a href="https://explorer.solana.com/account/{{ write_account.key }}?cluster={{config.cluster}}">
                                             <div class="d-none d-lg-flex align-items-center "><span class="font-size-tiny me-2"><span
                                                     class=""></span></span><span
-                                                    class="font-monospace"><span class="">{{write_account.key}}</span></span>
+                                                    class="font-monospace"><span class="">{{ write_account.key }}</span></span>
                                             </div>
                                         </a>
                                     </td>
@@ -176,16 +176,16 @@
                                         <a href="https://explorer.solana.com/account/{{ read_account.key }}?cluster={{config.cluster}}">
                                             <div class="d-none d-lg-flex align-items-center">
                                                 <span class="font-size-tiny me-2">
-                                                    <span class="font-monospace">{{read_account.key}}</span>
+                                                    <span class="font-monospace">{{ read_account.key }}</span>
                                                 </span>
                                             </div>
                                         </a>
                                     </td>
-                                    <td>{{read_account.cu_requested}}</td>
-                                    <td>{{read_account.cu_consumed}}</td>
-                                    <td>{{read_account.median_pf}}</td>
-                                    <td>{{read_account.min_pf}}</td>
-                                    <td>{{read_account.max_pf}}</td>
+                                    <td>{{ read_account.cu_requested | lamports }}</td>
+                                    <td>{{ read_account.cu_consumed | lamports }}</td>
+                                    <td>{{ read_account.median_pf | lamports }}</td>
+                                    <td>{{ read_account.min_pf | lamports }}</td>
+                                    <td>{{ read_account.max_pf | lamports }}</td>
 
                                 </tr>
                                 {% endfor %}


### PR DESCRIPTION
formats count, slot, lamports:

`{{ cu_requested | lamports }}`

`{{ num_transactions | count }}`

`{{ num_transactions | map_count }}` (preserve None instead of default to "")

`{{ block.slot | slotnumber }}`

> 123456789 to "123,456,789"


note:
* did not format **proc:2042 fail:42 bank:0** because it looked ugly
