### PR TITLE
remodel transactioninfos per slot

### DIFF
--- a/transaction_database.py
+++ b/transaction_database.py
@@ -13,7 +13,7 @@ def run_query():
             FROM banking_stage_results.transaction_infos
             WHERE true
             GROUP BY signature
-            ORDER BY min(utc_timestamp)
+            ORDER BY min(utc_timestamp) DESC
             LIMIT 50
         )
         SELECT

--- a/transaction_details_database.py
+++ b/transaction_details_database.py
@@ -8,7 +8,6 @@ def find_transaction_details_by_sig(tx_sig: str):
     # transaction table primary key is used
     maprows = postgres_connection.query(
         """
-        
         WITH tx_aggregated AS (
             SELECT
                 signature as sig,

--- a/transaction_details_database.py
+++ b/transaction_details_database.py
@@ -8,21 +8,29 @@ def find_transaction_details_by_sig(tx_sig: str):
     # transaction table primary key is used
     maprows = postgres_connection.query(
         """
-        SELECT * FROM (
+        
+        WITH tx_aggregated AS (
             SELECT
-                signature,
-                errors,
-                is_executed,
-                is_confirmed,
-                first_notification_slot,
-                cu_requested,
-                prioritization_fees,
-                processed_slot,
-                to_char(utc_timestamp, 'MON DD HH24:MI:SS.MS') as timestamp_formatted,
-                accounts_used
+                signature as sig,
+                min(first_notification_slot) as min_slot,
+                ARRAY_AGG(errors) as all_errors
             FROM banking_stage_results.transaction_infos
             WHERE signature = %s
-        ) AS data
+            GROUP BY signature
+        )
+        SELECT
+            signature,
+            tx_aggregated.all_errors,
+            is_executed,
+            is_confirmed,
+            first_notification_slot,
+            cu_requested,
+            prioritization_fees,
+            processed_slot,
+            to_char(utc_timestamp, 'MON DD HH24:MI:SS.MS') as timestamp_formatted,
+            accounts_used
+        FROM banking_stage_results.transaction_infos txi
+        INNER JOIN tx_aggregated ON tx_aggregated.sig=txi.signature AND tx_aggregated.min_slot=txi.first_notification_slot
         """, args=[tx_sig])
 
     assert len(maprows) <= 1, "Tx Sig is primary key - find zero or one"


### PR DESCRIPTION
Transaction-Info table now uses signature+first_notification_slot as primary key. One transaction_info is written per **errors** structure per slot.
All other fields are denormalized. any row could be  selected.

**errors** will be aggregated to **all_errors**: the structure is nested two levels deep:
1. Postgres array of texts (json)
2. JSON array with JSON objects

<img width="1288" alt="image" src="https://github.com/blockworks-foundation/solana-bankingstage-dashboard/assets/95291500/70339e57-3467-4794-8376-1bea48aef4a5">

