### PR TITLE
Bugfix/transactiondetails if txinfo missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Open Firefox Browser and navigate to ...
 ### Data Model
 
 * transaction data (irrespective of block inclusion):
-  * transaction_slot: transaction from banking stage plugin; reflecting errors trying to include transaction in block (block is designated by slot)
+  * transaction_slot: (banking stage only!), transaction from banking stage plugin; reflecting errors trying to include transaction in block (block is designated by slot)
   * accounts_map_transaction: mapping of accounts to transactions irrespective of block inclusion
 * related to a produced block (happens _after_ transaction data):
   * transaction_infos: transaction in blocks

--- a/transaction_database.py
+++ b/transaction_database.py
@@ -90,11 +90,12 @@ def search_transaction_by_sig(tx_sig: str):
 
 # return (rows, is_limit_exceeded)
 def search_transactions_by_address(account_key: str) -> (list, bool):
-    maprows = query_transactions_by_address(transaction_row_limit=101, account_key=account_key)
+    page_size = 10
+    maprows = query_transactions_by_address(transaction_row_limit=page_size+1, account_key=account_key)
 
-    if len(maprows) == 101:
+    if len(maprows) == page_size+1:
         print("limit exceeded while searching for transactions by address")
-        return maprows, True
+        return maprows[:page_size], True
 
     return maprows, False
 

--- a/transaction_database.py
+++ b/transaction_database.py
@@ -64,9 +64,12 @@ def query_transactions_by_address(account_key: str, transaction_row_limit=100):
         INNER JOIN unnest(amt_latest.tx_ids) WITH ORDINALITY AS amt_txs(transaction_id, sort_nr) ON true
         INNER JOIN banking_stage_results_2.accounts acc ON acc.acc_id=amt_latest.acc_id
         INNER JOIN banking_stage_results_2.transactions txs ON txs.transaction_id=amt_txs.transaction_id
-        INNER JOIN banking_stage_results_2.transaction_infos txi ON txi.transaction_id=amt_txs.transaction_id
         LEFT JOIN tx_slot_data ON tx_slot_data.transaction_id=amt_txs.transaction_id
-        WHERE account_key = %s
+        LEFT JOIN banking_stage_results_2.transaction_infos txi ON txi.transaction_id=amt_txs.transaction_id
+        WHERE true
+            -- note: check for txi is actually useless ATM as txi is always updated aling with amt_latest
+            AND (tx_slot_data IS NOT NULL OR txi IS NOT NULL)
+            AND account_key = %s
         ORDER BY sort_nr DESC
         LIMIT %s
         """, [

--- a/transaction_details_database.py
+++ b/transaction_details_database.py
@@ -10,29 +10,28 @@ def find_transaction_details_by_sig(tx_sig: str):
     # transaction table primary key is used
     maprows = postgres_connection.query(
         """
+        WITH tx_slot_data AS (
+            SELECT
+                transaction_id,
+                min(slot) AS first_slot,
+                min(utc_timestamp) AS min_utc_timestamp
+            FROM banking_stage_results_2.transaction_slot tx_slot
+            GROUP BY transaction_id
+        )
         SELECT
-            tx_slot_agg.transaction_id,
-            tx_slot_agg.signature,
-            tx_slot_agg.first_slot AS first_notification_slot,
-            tx_slot_agg.min_utc_timestamp AS utc_timestamp,
+            txs.transaction_id,
+            signature,
+            tx_slot_data.first_slot AS first_notification_slot,
+            tx_slot_data.min_utc_timestamp AS utc_timestamp,
             -- optional fields from transaction_infos
             txi.is_successful,
             txi.processed_slot,
             txi.cu_requested,
             txi.prioritization_fees
-        FROM (
-            SELECT
-                signature,
-                -- note: min() is arbitrary
-                min(tx_slot.transaction_id) AS transaction_id,
-                min(slot) AS first_slot, min(utc_timestamp) AS min_utc_timestamp
-            FROM banking_stage_results_2.transaction_slot tx_slot
-            INNER JOIN banking_stage_results_2.transactions txs ON txs.transaction_id=tx_slot.transaction_id
-            LEFT JOIN banking_stage_results_2.transaction_infos txi ON txi.transaction_id=tx_slot.transaction_id
-            WHERE txs.signature = %s
-            GROUP BY signature
-        ) as tx_slot_agg
-        LEFT JOIN banking_stage_results_2.transaction_infos txi ON txi.transaction_id=tx_slot_agg.transaction_id
+        FROM tx_slot_data
+        INNER JOIN banking_stage_results_2.transactions txs ON txs.transaction_id=tx_slot_data.transaction_id
+        LEFT JOIN banking_stage_results_2.transaction_infos txi ON txi.transaction_id=txs.transaction_id
+        WHERE txs.signature = %s
         """, args=[tx_sig])
 
     assert len(maprows) <= 1, "Tx Sig is primary key - find zero or one"


### PR DESCRIPTION
aligned query pattern for transaction_info and transaction_slot; make sure, that incomplete transactions are returned in transaction details and transaction lists.
When using tx-array from accounts_map_transaction_latest make sure, that the transactions actually have data either in transaction_info or transaction_slot

See [scenarios](https://github.com/blockworks-foundation/solana-bankingstage-dashboard/issues/45#issuecomment-1884425224)

